### PR TITLE
move event_loader,event_handler; make it executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ SHAREDIR ?= $(PREFIX)/share/hyprevents
 
 install: event_handler event_loader hyprevents
 	@install -Dm644 event_handler --target-directory "$(SHAREDIR)"
-	@install -Dm655 event_loader --target-directory "$(SHAREDIR)"
+	@install -Dm755 event_loader --target-directory "$(SHAREDIR)"
 	@install -Dm755 hyprevents --target-directory "$(BINDIR)"

--- a/event_loader
+++ b/event_loader
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # load the default (empty) event implementations
-. /usr/share/hyprevents/event_handler
+. `dirname $0`/event_handler
 
 PFS=$IFS
 

--- a/hyprevents
+++ b/hyprevents
@@ -53,8 +53,8 @@ argparse() {
 argparse $0 "$@"
 
 [ -z "$EVENT_FILE" ] && echo "Event handler not provided." && usage && exit
-[ $KILL == 1 ] && pkill -f "/usr/share/hyprevents/event_loader $EVENT_FILE" && exit
-[ $RELOAD == 1 ] && pkill -USR1 -f "/usr/share/hyprevents/event_loader $EVENT_FILE" && exit
+[ $KILL == 1 ] && pkill -f "$(dirname `dirname $0`)/share/hyprevents/event_loader $EVENT_FILE" && exit
+[ $RELOAD == 1 ] && pkill -USR1 -f "$(dirname `dirname $0`)/share/hyprevents/event_loader $EVENT_FILE" && exit
 
 socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock \
-         EXEC:"/usr/share/hyprevents/event_loader $EVENT_FILE",nofork
+	EXEC:"$(dirname `dirname $0`)/share/hyprevents/event_loader $EVENT_FILE",nofork


### PR DESCRIPTION
Moved from /usr/share to /usr/bin to signify they're executable. Use relative paths (dirname $0) to allow for PREFIXes that are not /usr.

Changed permissions: socat seems to fail when event_handler and event_loader are not executable.

https://github.com/NixOS/nixpkgs/pull/278114