### PR TITLE
Update shebangs to /usr/bin/env

### DIFF
--- a/event_handler
+++ b/event_handler
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # default handlers for hyprevents
 #

--- a/event_loader
+++ b/event_loader
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 EVENT_HANDLER="$(dirname "$0")/event_handler"
 

--- a/hyprevents
+++ b/hyprevents
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     cat <<EOF


### PR DESCRIPTION
On NixOS, Termux etc the sh/bash shells are not located in /bin

This PR fixes the following error on these distros:

```shell
./hyprevents
zsh: ./hyprevents: bad interpreter: /bin/bash: no such file or directory
```